### PR TITLE
JMC-6082: JOverflow does not handle large heap dumps well

### DIFF
--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/heap/parser/ReadBuffer.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/heap/parser/ReadBuffer.java
@@ -105,8 +105,9 @@ public abstract class ReadBuffer {
 			RandomAccessFile file = new RandomAccessFile(fileName, "r");
 			try {
 				return CachedReadBuffer.createInstance(file, preferredCacheSize);
-			} finally {
+			} catch (IOException e) {
 				IOToolkit.closeSilently(file);
+				throw e;
 			}
 		}
 	}


### PR DESCRIPTION
Summary: Corrected CachedReadBufferFactory from closing dump files prematurely
Contributed-by: Kangcheng Xu <kxu@redhat.com>